### PR TITLE
Final update for 1.25

### DIFF
--- a/PVS_HealthCheck_ReadMe.rtf
+++ b/PVS_HealthCheck_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -47,79 +47,74 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext17 \sqformat \spriority1 \styrsid14894181 No Spacing;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid14894181 
 Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid10227609 Mention;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf22\chshdng0\chcfpat0\chcbpat23 
-\sbasedon10 \ssemihidden \sunhideused \styrsid4947640 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1565240990\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid282074041}{\list\listtemplateid-1612023500\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1236917028\listhybrid{\listlevel\levelnfc23
-\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid558714133}{\list\listtemplateid-990473222\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid642077380}{\list\listtemplateid1184951006\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
-\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers
-;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
-\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid676005662}{\list\listtemplateid-546045730\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2520\lin2520 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3240\lin3240 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3960\lin3960 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4680\lin4680 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5400\lin5400 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li6120\lin6120 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6840\lin6840 }{\listname ;}\listid872425844}{\list\listtemplateid1500158440\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid1217358328}{\list\listtemplateid1020826486
-\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace360\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 
-\fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel
-\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23
-\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}{\list\listtemplateid-879616424\listhybrid{\listlevel\levelnfc23\levelnfcn23
+\sbasedon10 \ssemihidden \sunhideused \styrsid4947640 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
+\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
+\fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid282074041}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace0\levelindent0{\leveltext\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-720\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
+\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid558714133}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
+\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid642077380}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 
+\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid676005662}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2520\lin2520 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3240\lin3240 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3960\lin3960 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4680\lin4680 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5400\lin5400 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li6120\lin6120 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6840\lin6840 }{\listname ;}\listid872425844}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace360\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1217358328}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0
+\levelspace360\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 
+\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
 {\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
@@ -128,24 +123,24 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel
 \levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid2002729840}
-{\list\listtemplateid-1055998564\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
-{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
-\listoverridecount0\ls8}{\listoverride\listid2002729840\listoverridecount0\ls9}{\listoverride\listid282074041\listoverridecount0\ls10}}{\*\rsidtbl \rsid201962\rsid472113\rsid599009\rsid804820\rsid1142629\rsid1262568\rsid2246377\rsid2584501\rsid2585069
-\rsid2780296\rsid3022886\rsid3085909\rsid3232403\rsid3612416\rsid3637189\rsid4090611\rsid4482658\rsid4540678\rsid4940151\rsid4947640\rsid4997743\rsid5184380\rsid5916941\rsid6963519\rsid7282308\rsid7634902\rsid8924948\rsid9244280\rsid9438945\rsid9635381
-\rsid9646566\rsid9661052\rsid10106340\rsid10227609\rsid10382262\rsid10704264\rsid10752920\rsid11218240\rsid11686791\rsid12087820\rsid12282547\rsid12348097\rsid12615477\rsid13134628\rsid13253201\rsid13729317\rsid14370152\rsid14580330\rsid14894181
-\rsid15038176}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2021\mo1\dy25\hr11}{\version42}
-{\edmins164}{\nofpages9}{\nofwords2356}{\nofchars13433}{\nofcharsws15758}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 
+}{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel
+\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0
+\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133
+\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}
+{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}{\listoverride\listid2002729840\listoverridecount0\ls9}{\listoverride\listid282074041
+\listoverridecount0\ls10}}{\*\rsidtbl \rsid201962\rsid472113\rsid599009\rsid804820\rsid1142629\rsid1262568\rsid2246377\rsid2584501\rsid2585069\rsid2780296\rsid3022886\rsid3085909\rsid3232403\rsid3612416\rsid3637189\rsid4090611\rsid4482658\rsid4540678
+\rsid4940151\rsid4947640\rsid4997743\rsid5184380\rsid5916941\rsid6963519\rsid7093264\rsid7282308\rsid7634902\rsid8924948\rsid9244280\rsid9438945\rsid9635381\rsid9646566\rsid9661052\rsid10106340\rsid10227609\rsid10382262\rsid10704264\rsid10752920
+\rsid11218240\rsid11686791\rsid12087820\rsid12282547\rsid12348097\rsid12615477\rsid13134628\rsid13253201\rsid13729317\rsid14370152\rsid14580330\rsid14894181\rsid15038176}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
+\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2022\mo3\dy6\hr5\min46}{\version43}{\edmins165}{\nofpages9}{\nofwords2356}{\nofchars13430}{\nofcharsws15755}{\vern43}}
+{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjWyNLIwMTE1MzA1NTJU0lEKTi0uzszPAykwNKoFANAYLQYtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -198,19 +193,19 @@ s}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch
 ll-documentation-script-with-remoting/"}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d007000
 760073002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00036d6500
-5400}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/using-my-citrix-pvs-powershel\hich\af37\dbch\af31505\loch\f37 l-documentation-script-with-remoting/}}}
+540000}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/using-my-citrix-pvs-powershe\hich\af37\dbch\af31505\loch\f37 ll-documentation-script-with-remoting/}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bbc000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e00740061007400
-69006f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00036900477500}}}{\fldrslt {\rtlch\fcs1 
+69006f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003690047750000}}}{\fldrslt {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.com/error-in-the-provisioning-servic\hich\af37\dbch\af31505\loch\f37 
 es-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0c010000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f007600
 6900730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d
-0061006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000369613a6900}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 
+0061006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000369613a690000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid472113 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\PVS_}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9244280 \hich\af37\dbch\af31505\loch\f37 HealthCheck}{\rtlch\fcs1 
@@ -415,7 +410,7 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    8
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -423,7 +418,7 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, thi\hich\af2\dbch\af31505\loch\f2 s is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    9
@@ -431,18 +426,18 @@ TNPVSFarm_HealthCheck_AppendixQ_ServerNICItemsToReview.csv}{\rtlch\fcs1 \af2\afs
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This c\hich\af2\dbch\af31505\loch\f2 mdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2     <Comm\hich\af2\dbch\af31505\loch\f2 onParameters>
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go\hich\af2\dbch\af31505\loch\f2 
-.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParame\hich\af2\dbch\af31505\loch\f2 ters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid472113 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030039007300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid472113 \hich\af2\dbch\af31505\loch\f2 
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003900730001}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid472113 \hich\af2\dbch\af31505\loch\f2 
 https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to th\hich\af2\dbch\af31505\loch\f2 is script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  \hich\af2\dbch\af31505\loch\f2 You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -455,12 +450,10 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_HealthCheck.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5184380 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7093264 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5184380 \hich\af2\dbch\af31505\loch\f2 much}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \hich\af2\dbch\af31505\loch\f2  help from BG a, now former, Citrix dev)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3022886 \hich\af2\dbch\af31505\loch\f2 January }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5184380 \hich\af2\dbch\af31505\loch\f2 2}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11686791 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3022886 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280\charrsid9244280 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7093264 \hich\af2\dbch\af31505\loch\f2 March 6, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -473,7 +466,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster -Domain }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10106340 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 WebstersLab
@@ -491,7 +484,7 @@ another domain or forest.
 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 Uses Get-Credential to prompt for the password.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid9244280 
 \par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9244280 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1 -AdminAddress PVS1 -User cwebster
 \par 
@@ -499,8 +492,8 @@ another domain or forest.
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 Uses Get-Credential to pr
-\hich\af2\dbch\af31505\loch\f2 ompt for the password.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid9244280 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 Uses Get-Credential to prompt for t
+\hich\af2\dbch\af31505\loch\f2 he password.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid9244280 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par 
@@ -610,12 +603,12 @@ unauthenticated email using an email relay server requires the From email }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 
 \hich\af2\dbch\af31505\loch\f2 https://support.google.com/a/answer/2956491?hl=en}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4997743 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00036e}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid7634902\charrsid5916941 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00036e6c}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid7634902\charrsid5916941 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9244280 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020b00000000000006e63}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020b00000000000006e6300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
@@ -647,9 +640,9 @@ labaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4997743 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid7634902\charrsid5916941 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-offic
-\hich\af2\dbch\af31505\loch\f2 e-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid7634902\charrsid5916941 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/\hich\af2\dbch\af31505\loch\f2 
+how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
@@ -658,9 +651,9 @@ labaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
  the email server labaddomain-com.mail.protection.outlook.com,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \hich\af2\dbch\af31505\loch\f2 sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 
-\hich\af2\dbch\af31505\loch\f2 SomeEmailAddress@labaddomain.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
-\hich\af2\dbch\af31505\loch\f2 sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 f\hich\af2\dbch\af31505\loch\f2 rom }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 SomeEmailAddress@labaddomain.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
  the default SMTP port 25 and SSL.
@@ -671,11 +664,11 @@ labaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
-\hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.office365.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
-\hich\af2\dbch\af31505\loch\f2 -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
+\hich\af2\dbch\af31505\loch\f2 -SmtpS\hich\af2\dbch\af31505\loch\f2 erver smtp.office365.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2     -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster\hich\af2\dbch\af31505\loch\f2 .com}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@CarlWebster.com
+\f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 
  the email server smtp.office365.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
@@ -691,8 +684,8 @@ labaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_HealthCheck.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
-\hich\af2\dbch\af31505\loch\f2 -SmtpServe\hich\af2\dbch\af31505\loch\f2 r smtp.gmail.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScri\hich\af2\dbch\af31505\loch\f2 pt >.\\PVS_HealthCheck.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.gmail.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \hich\af2\dbch\af31505\loch\f2 -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2     -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com}{
@@ -709,10 +702,10 @@ email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af
  the email server smtp.gmail.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902 \hich\af2\dbch\af31505\loch\f2 
- and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@carlwebster.com.
+ and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 \hich\af2\dbch\af31505\loch\f2 s\hich\af2\dbch\af31505\loch\f2 ending to ITGroup@carlwebster.com.
 \par 
-\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7634902 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are n
-\hich\af2\dbch\af31505\loch\f2 ot valid to send an email, the script prompts 
+\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7634902 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid7634902 \hich\af2\dbch\af31505\loch\f2 
+    If the current user's credentials are not valid to send an email, the script prompts 
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7634902\charrsid9244280 
 \par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9244280 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280\charrsid9244280 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9244280 
@@ -836,8 +829,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000a06d
-dd9e3bf3d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f083
+b0cb4f31d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_HealthCheck_Script_ChangeLog.txt
+++ b/PVS_HealthCheck_Script_ChangeLog.txt
@@ -3,6 +3,22 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
+#Version 1.25 6-Mar-2022
+#	Added MultiSubnetFailover to Farm Status section
+#		Thanks to Arnaud Pain
+#		I can't believe no one has asked for this since PVS 7.11 was released on 14-Sep-2016
+#	Fixed a bug in Function GetInstalledRolesAndFeatures that didn't handle the condition of no installed Roles or Features
+#		Thanks to Arnaud Pain for reporting this
+#	Fixed bug when retrieving a Device Collection's Administrators and Operators
+#		I was not comparing to the specific device collection name, which returned all administrators and 
+#		operators for all device collections and not the device collection being processed 
+#	Fixed several incorrect variable names
+#	Format the Farm, Properties, Status section to match the console output
+#	In Function GetConfigWizardInfo, fix $PXEServices to work with PVS7+
+#		If DHCPType is equal to 1073741824, then if PXE is set to PVS,
+#		in PVS V5/6, PXEType is set to 0, but in PVS7, PXEType is set to 1
+#		Updated the function to check for both 0 and 1 values
+
 #Version 1.24 25-Jan-2021
 #	Added Appendix R for Installed Citrix Components
 #		Added array $Script:CtxInstalledComponents


### PR DESCRIPTION
#Version 1.25 6-Mar-2022
#	Added MultiSubnetFailover to Farm Status section
#		Thanks to Arnaud Pain
#		I can't believe no one has asked for this since PVS 7.11 was released on 14-Sep-2016
#	Fixed a bug in Function GetInstalledRolesAndFeatures that didn't handle the condition of no installed Roles or Features
#		Thanks to Arnaud Pain for reporting this
#	Fixed bug when retrieving a Device Collection's Administrators and Operators
#		I was not comparing to the specific device collection name, which returned all administrators and 
#		operators for all device collections and not the device collection being processed 
#	Fixed several incorrect variable names
#	Format the Farm, Properties, Status section to match the console output
#	In Function GetConfigWizardInfo, fix $PXEServices to work with PVS7+
#		If DHCPType is equal to 1073741824, then if PXE is set to PVS,
#		in PVS V5/6, PXEType is set to 0, but in PVS7, PXEType is set to 1
#		Updated the function to check for both 0 and 1 values